### PR TITLE
set Julia compatibility to 1.3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,4 +11,4 @@ OpenEXR_jll = "18a262bb-aa17-5467-a713-aee519bc75cb"
 [compat]
 Colors = "0.12"
 FileIO = "1.0, 1.8"
-julia = "1"
+julia = "1.3"


### PR DESCRIPTION
[The artifacts feature](https://julialang.org/blog/2019/11/artifacts/) requires Julia at least v1.3, and `OpenEXR_jll` is an artifact binding package.

We'll also need to modify the General registry later so that people with Julia < 1.3 don't run into the OpenEXR v0.1.0 that is actually incompatible.